### PR TITLE
Fixed splitters being placed offset, by correcting the width.

### DIFF
--- a/outpost.js
+++ b/outpost.js
@@ -71,7 +71,7 @@ module.exports = function(string, opt) {
   const newEntityData = {};
   newEntityData[REQUEST_TYPE] = { type: 'item' };
   newEntityData[BELT_NAME+'transport_belt'] = { type: 'item', width: 1, height: 1 };
-  newEntityData[BELT_NAME+'splitter'] = { type: 'item', width: 1, height: 1 };
+  newEntityData[BELT_NAME+'splitter'] = { type: 'item', width: 2, height: 1 };
   newEntityData[BELT_NAME+'underground_belt'] = { type: 'item', width: 1, height: 1, directionType: true };
 
   newEntityData[MINING_DRILL_NAME] = { type: 'item', width: 3, height: 3 };


### PR DESCRIPTION
Hi,

When looking around in the code I noticed the width of a splitter was 1 instead of 2. This change seems to have fixed the problem with splitters being placed offset ( #5 ), and it does not seem to break anything else in my testing.

I hope this helps,
Michiel Visser