### PR TITLE
Improve CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 Generates an outpost given a blueprintString with 2 walls at the corner of the ore patch you want to cover. Options are:
 
-- trainDirection: 0-3, side train station should enter from (0 is top) (default 2 bottom)
-- trainSide: 0-3, side the train station should be on (Must be perpendicular to minedOreDirection) (default 1 right)
+- trainSide: 0-3, side the train station should be on (default 1 right)
+- trainDirection: 0-3, side train station should enter from (Must be perpendicular to trainSide) (default 2 bottom)
 - minerSpace: 0-2, space between miners (default 1)
 - module: Module name to fill up miners with, empty for none
 - includeRadar: Boolean, whether or not to include a radar (default true)

--- a/cli
+++ b/cli
@@ -6,20 +6,21 @@ const YAML = require('yamljs');
 
 const options = [
     {
-        name: 'minedOreDirection',
-        alias: 'direction',
-        description: '0-3 direction ore should flow when mined (0 is up) (default 2)'
-    },
-    {
         name: 'oilOutpost',
         alias: 'oil',
         description: 'Generate an oil outpost instead of an ore outpost'
     },
     {
+        name: 'trainSide',
+        description: '0-3, side the train station should be on (default 1 right)'
+    },
+    {
         name: 'trainDirection',
-        alias: 'train',
-        description: '0-3, Side the train station should be on (Must be perpendicular to minedOreDirection) (default 1)'
-
+        description: '0-3, side train station should enter from (Must be perpendicular to trainSide) (default 2 bottom)'
+    },
+    {
+        name: 'beacons',
+        description: 'Booleann, whether to use beacons (default false)'
     },
     {
         name: 'minerSpace',
@@ -268,7 +269,8 @@ if (Object.keys(args).length >= 1) {
 }
 
 try {
-    console.log(opts.oilOutpost ? GENERATOR.oilOutpost(blueprint, opts) : GENERATOR.outpost(blueprint, opts));
+    global.console = new console.Console({ stdout: process.stderr, stderr: process.stderr });
+    process.stdout.write(opts.oilOutpost ? GENERATOR.oilOutpost(blueprint, opts) : GENERATOR.outpost(blueprint, opts));
 } catch (e) {
     console.log(e.message);
 }


### PR DESCRIPTION
* The cli seems to have been forgotten when minedOreDirection turned into trainSide. This fixes the leftover stuff.
* Adds a beacon flag to the cli.
* Causes the cli to write all of its messages to stderr, so only the blueprint is ever printed to stdout.