### PR TITLE
add special rules for landfill under curved and diagonal rails

### DIFF
--- a/tools/blueprintTool.js
+++ b/tools/blueprintTool.js
@@ -1,4 +1,5 @@
 const Blueprint = require('factorio-blueprint');
+const generateLandfill = require('./lib/landfill');
 module.exports = function(string, opt) {
   opt = opt || {};
 
@@ -211,17 +212,7 @@ module.exports = function(string, opt) {
 
     if (LANDFILL_ENTITIES) {
       bp.entities.forEach(e => {
-        if (e.name !== 'offshore_pump') {
-          // offshore pumps are built on water
-          for (let ox = 0; ox < e.size.x; ox++) {
-            for (let oy = 0; oy < e.size.y; oy++) {
-              bp.createTile('landfill', {
-                x: e.position.x + ox,
-                y: e.position.y + oy,
-              });
-            }
-          }
-        }
+        generateLandfill(e, bp);
       });
     }
   }

--- a/tools/lib/landfill.js
+++ b/tools/lib/landfill.js
@@ -1,0 +1,65 @@
+// `curved_rail`s require special landfill shapes. the below offsets were generated in `/editor` mode using Factorio 1.1.59
+const curvedRailLandfillRequirementsByDirection = [
+  [[-3, -3], [-3, -2], [-2, -4], [-2, -3], [-2, -2], [-2, -1], [-1, -3], [-1, -2], [-1, -1], [-1, 0], [0, -2], [0, -1], [0, 0], [0, 1], [0, 2], [0, 3], [1, 0], [1, 1], [1, 2], [1, 3]],
+  [[-2, 0], [-2, 1], [-2, 2], [-2, 3], [-1, -2], [-1, -1], [-1, 0], [-1, 1], [-1, 2], [-1, 3], [0, -3], [0, -2], [0, -1], [0, 0], [1, -4], [1, -3], [1, -2], [1, -1], [2, -3], [2, -2]],
+  [[-4, 0], [-4, 1], [-3, 0], [-3, 1], [-2, 0], [-2, 1], [-1, -1], [-1, 0], [-1, 1], [0, -2], [0, -1], [0, 0], [1, -3], [1, -2], [1, -1], [1, 0], [2, -3], [2, -2], [2, -1], [3, -2]],
+  [[-4, -2], [-4, -1], [-3, -2], [-3, -1], [-2, -2], [-2, -1], [-1, -2], [-1, -1], [-1, 0], [0, -1], [0, 0], [0, 1], [1, -1], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2], [3, 1]],
+  [[-2, -4], [-2, -3], [-2, -2], [-2, -1], [-1, -4], [-1, -3], [-1, -2], [-1, -1], [-1, 0], [-1, 1], [0, -1], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [1, 3], [2, 1], [2, 2]],
+  [[-3, 1], [-3, 2], [-2, 0], [-2, 1], [-2, 2], [-2, 3], [-1, -1], [-1, 0], [-1, 1], [-1, 2], [0, -4], [0, -3], [0, -2], [0, -1], [0, 0], [0, 1], [1, -4], [1, -3], [1, -2], [1, -1]],
+  [[-4, 1], [-3, 0], [-3, 1], [-3, 2], [-2, -1], [-2, 0], [-2, 1], [-2, 2], [-1, -1], [-1, 0], [-1, 1], [0, -2], [0, -1], [0, 0], [1, -2], [1, -1], [2, -2], [2, -1], [3, -2], [3, -1]],
+  [[-4, -2], [-3, -3], [-3, -2], [-3, -1], [-2, -3], [-2, -2], [-2, -1], [-2, 0], [-1, -2], [-1, -1], [-1, 0], [0, -1], [0, 0], [0, 1], [1, 0], [1, 1], [2, 0], [2, 1], [3, 0], [3, 1]],
+];
+
+// diagonal `straight_rail`s require less landfill than their `size`-based bounding box. the below offsets were generated in `/editor` mode using Factorio 1.1.59
+const straightRailLandfillRequirementsByDirection = [
+  undefined, // not diagonal, so default to standard rectangle
+  [[0, 0], [1, -1], [1, 0], [1, 1], [2, 0]],
+  undefined, // not diagonal, so default to standard rectangle
+  [[0, 1], [1, 0], [1, 1], [1, 2], [2, 1]],
+  undefined, // not diagonal, so default to standard rectangle
+  [[-1, 1], [0, 0], [0, 1], [0, 2], [1, 1]],
+  undefined, // not diagonal, so default to standard rectangle
+  [[-1, 0], [0, -1], [0, 0], [0, 1], [1, 0]],
+];
+
+function getSpecialLandfillOffsets(entity) {
+  if (entity.name === 'curved_rail') {
+    return curvedRailLandfillRequirementsByDirection[entity.direction ?? 0];
+  }
+  else if (entity.name === 'straight_rail') {
+    return straightRailLandfillRequirementsByDirection[entity.direction ?? 0];
+  }
+  return undefined;
+}
+
+function generateLandfill(e, bp) {
+  // offshore pumps are built on water, so don't create landfill for them
+  if (e.name === 'offshore_pump') {
+    return;
+  }
+
+  // look up if there is a special offset list for this entity
+  let specialOffsets = getSpecialLandfillOffsets(e)
+  if (specialOffsets !== undefined) {
+    for (const offset of specialOffsets) {
+      bp.createTile('landfill', {
+        x: e.position.x + offset[0],
+        y: e.position.y + offset[1],
+      });
+    }
+  }
+
+  // otherwise, add a rectangle of landfill defined by the entity's 'size' property
+  else {
+    for (let ox = 0; ox < e.size.x; ox++) {
+      for (let oy = 0; oy < e.size.y; oy++) {
+        bp.createTile('landfill', {
+          x: e.position.x + ox,
+          y: e.position.y + oy,
+        });
+      }
+    }
+  }
+}
+
+module.exports = generateLandfill;


### PR DESCRIPTION
The existing landfill code uses bounding boxes defined by the `size` property of the blueprint's `entity`. Curved rails do not seem to have a `size` property, so no landfill is generated for them. Diagonal rails fit in a smaller space than their bounding box, which results in wasted landfill and a blocky appearance.

This PR adds a lookup table for special offsets for curved and diagonal rails which was generated by creating blueprints for each rail section atop (pruned) landfill in `/editor` mode using Factorio 1.1.59.

Before:
![before](https://user-images.githubusercontent.com/529800/175750834-5453a6dd-4b4c-48c7-90c8-d30cd33cc205.png)

After:
![after](https://user-images.githubusercontent.com/529800/175750836-d83f2e26-e392-49ad-83be-70547ce50f97.png)

Using [Kitch's 2 Lane Rail Book - 3.2 on FactorioPrints](https://factorioprints.com/view/-M7pQZqM_0T_1_FoGUub)

P.S. Thanks for the great web service! <3